### PR TITLE
ac_imageio: add actiff format wth tag metadata reader

### DIFF
--- a/acpreprocessing/__init__.py
+++ b/acpreprocessing/__init__.py
@@ -1,1 +1,4 @@
 from . import utils
+
+# set up actiff imageio format
+from .utils import ac_imageio

--- a/acpreprocessing/utils/ac_imageio.py
+++ b/acpreprocessing/utils/ac_imageio.py
@@ -1,0 +1,25 @@
+import imageio
+
+
+class ACTiffFormat(imageio.plugins.tifffile.TiffFormat):
+    class Reader(imageio.plugins.tifffile.TiffFormat.Reader):
+        def _get_meta_data(self, index):
+            meta = super()._get_meta_data(index)
+            page = self._tf.pages[index or 0]
+            meta["acquisition_md"] = page.tags[51123].value
+            return meta
+
+        def _get_data(self, index):
+            im, meta = super()._get_data(index)
+            return im, self._get_meta_data(index or 0)
+
+
+fmt = ACTiffFormat(
+    "actiff",
+    "tiff format for AIBS axonal connectomics",
+    ".actiff",
+    "iIvV"
+)
+
+imageio.formats.add_format(fmt, overwrite=True)
+


### PR DESCRIPTION
this adds metadata to the .meta field of objects returned by e.g. `imageio.volread(img_fn, format="actiff")` and gives tag metadata access through `imageio.get_reader(img_fn, format="actiff").get_meta_data()["acquisition_md"]`