### PR TITLE
deskew: add output shape estimation and remove lls_dd imports

### DIFF
--- a/acpreprocessing/deskewing.py
+++ b/acpreprocessing/deskewing.py
@@ -4,8 +4,6 @@ import matplotlib.pyplot as plt
 from numpy.linalg import inv
 import json
 import time
-from lls_dd.transform_helpers import *
-from lls_dd.transforms import *
 from scipy.ndimage import affine_transform
 import logging
 logging.getLogger("tifffile").setLevel(logging.ERROR)
@@ -16,8 +14,45 @@ import os
 from PIL import Image
 import time
 
+
+def transformed_vol_dims(aff_mtx, shape):
+    """get output dimensions of a 3D volume given a 4x4 affine transform.
+      Rounds up to match results in lls_dd.
+
+    Parameters
+    ----------
+    aff_mtx: numpy.ndarray
+        4x4 affine transformation matrix
+    shape: iterable
+        shape of 3d volume to be transformed
+
+    Returns
+    -------
+    dims:
+        expected dimensions of output volume
+    """
+    d0, d1, d2 = [s-1 for s in shape]
+    homogeneous_corner_pts = np.array([
+        [0, 0, 0, 1],
+        [d0, 0, 0, 1],
+        [0, d1, 0, 1],
+        [0, 0, d2, 1],
+        [d0, d1, 0, 1],
+        [d0, 0, d2, 1],
+        [0, d1, d2, 1],
+        [d0, d1, d2, 1]
+    ])
+    # nonhomogeneous transformed corner points
+    tformed_corner_pts = np.dot(aff_mtx, homogeneous_corner_pts.T).T[:, :-1]
+    # add 1 to peak-to-peak to avoid fencepost
+    dims = tformed_corner_pts.ptp(axis=0) + 1
+    # round to next multiple of 2
+    dims = (np.ceil(dims / 2.) * 2).astype(int)
+    return dims
+
+
 def deskew_from_config(vol,config):
-	
+
 	xypixelsize = config['xypixelsize']
 	angle = config ['angle']
 	dzstage = config['zstage']
@@ -31,6 +66,6 @@ def deskew_from_config(vol,config):
 	skew = np.eye(4)
 	skew[2,0] = deskewfactor
 	print(skew)
-	output_shape = get_output_dimensions(skew, vol)
+	output_shape = transformed_vol_dims(skew, vol.shape)
 	deskewed = affine_transform(vol, np.linalg.inv(skew),output_shape=output_shape,order=1)
 	return deskewed


### PR DESCRIPTION
lls_dd is not in requirements (and not packaged on pypi or conda) and is not currently used anywhere else in this repo.  The function it was serving in deskewing was minimal, so I wrote a new function to give the same answer.
We can add it as an actual dependency (or an optional one) in the future, but it doesn't make sense to fail on import for a somewhat trivial function.

I haven't thought much about how to test this, since the function is strictly trying to match the lls_dd output and there wasn't a deskewing test before.  We could test with a `pi/4` rotation on a cube and make sure the dimensions are as expected for the `transformed_vol_dims`.  For a general deskew test, we could probably do a deskew/reskew cycle and count the pre/post nonblack pixels.  Both of these methods probably have an error threshold that makes them more about testing that the code runs than it being correct.