### PR TITLE
ac_imageio: update import for lazy imageio plugins

### DIFF
--- a/acpreprocessing/utils/ac_imageio.py
+++ b/acpreprocessing/utils/ac_imageio.py
@@ -1,4 +1,5 @@
 import imageio
+import imageio.plugins.tifffile
 
 
 class ACTiffFormat(imageio.plugins.tifffile.TiffFormat):


### PR DESCRIPTION
This should fix tests currently failing on importing ac_imageio (see #11 )