### PR TITLE
acquisition dir to n5 dir script

### DIFF
--- a/acpreprocessing/stitching_modules/convert_to_n5/acquisition_dir_to_n5_dir.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/acquisition_dir_to_n5_dir.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+"""write n5 format directory given an axonal connectomics
+tiff style acquisition directory
+"""
+import concurrent.futures
+import json
+import pathlib
+import shutil
+
+import argschema
+
+from acpreprocessing.stitching_modules.convert_to_n5.tiff_to_n5 import (
+    tiffdir_to_n5_group,
+    N5GenerationParameters
+)
+
+
+def yield_position_paths_from_rootdir(
+        root_dir, stripjson_bn="hh.log",
+        stripjson_key="stripdirs"):
+    root_path = pathlib.Path(root_dir)
+    stripjson_path = root_path / stripjson_bn
+    with stripjson_path.open() as f:
+        stripjson_md = json.load(f)
+    stripdirs_bns = stripjson_md[stripjson_key]
+    for stripdir_bn in stripdirs_bns:
+        yield root_path / stripdir_bn
+
+
+def get_pixel_resolution_from_rootdir(
+        root_dir, md_bn="acquisition_metadata.json"):
+    root_path = pathlib.Path(root_dir)
+    md_path = root_path / md_bn
+    with md_path.open() as f:
+        md = json.load(f)
+    xy = md["settings"]["pixel_spacing_um"]
+    z = md["positions"][1]["x_step_um"]
+    return [xy, xy, z]
+
+
+def acquisition_to_n5(acquisition_dir, out_dir, concurrency=5,
+                      n5_generation_kwargs=None, copy_top_level_files=True):
+    """
+    """
+    n5_generation_kwargs = (
+        {} if n5_generation_kwargs is None
+        else n5_generation_kwargs)
+
+    acquisition_path = pathlib.Path(acquisition_dir)
+    out_path = pathlib.Path(out_dir)
+    out_n5_dir = str(out_path / f"{out_path.name}.n5")
+
+    try:
+        group_attributes = {
+            "pixelResolution": {
+                "dimensions": get_pixel_resolution_from_rootdir(
+                    acquisition_path),
+                "unit": "um"
+            }
+        }
+    except (KeyError, FileNotFoundError):
+        group_attributes = {}
+
+    with concurrent.futures.ProcessPoolExecutor(max_workers=concurrency) as e:
+        futs = []
+        for i, pospath in enumerate(
+                yield_position_paths_from_rootdir(
+                    acquisition_path)):
+            # pos_group = pospath.name
+            # below is more like legacy structure
+            # out_n5_dir = str(out_path / f"{pos_group}.n5")
+            futs.append(e.submit(
+                tiffdir_to_n5_group,
+                str(pospath), out_n5_dir, [f"setup{i}", "timepoint0"],
+                group_attributes=[group_attributes], **n5_generation_kwargs
+            ))
+
+        for fut in concurrent.futures.as_completed(futs):
+            _ = fut.result()
+
+    if copy_top_level_files:
+        top_level_files_paths = [
+            p for p in acquisition_path.iterdir()
+            if p.is_file()]
+        for tlf_path in top_level_files_paths:
+            out_tlf_path = out_path / tlf_path.name
+            shutil.copy(str(tlf_path), str(out_tlf_path))
+
+
+class AcquisitionDirToN5DirParameters(
+        argschema.ArgSchema, N5GenerationParameters):
+    input_dir = argschema.fields.Str(required=True)
+    output_dir = argschema.fields.Str(required=True)
+    copy_top_level_files = argschema.fields.Bool(required=False, default=True)
+    position_concurrency = argschema.fields.Int(required=False, default=5)
+
+
+class AcquisitionDirToN5Dir(argschema.ArgSchemaParser):
+    default_schema = AcquisitionDirToN5DirParameters
+
+    def _get_n5_kwargs(self):
+        n5_keys = {
+            "max_mip", "concurrency", "compression",
+            "lvl_to_mip_kwargs", "chunk_size", "mip_dsfactor"}
+        return {k: self.args[k] for k in (n5_keys & self.args.keys())}
+
+    def run(self):
+        n5_kwargs = self._get_n5_kwargs()
+        acquisition_to_n5(
+            self.args["input_dir"], self.args["output_dir"],
+            concurrency=self.args["position_concurrency"],
+            n5_generation_kwargs=n5_kwargs,
+            copy_top_level_files=self.args["copy_top_level_files"]
+            )
+
+
+if __name__ == "__main__":
+    mod = AcquisitionDirToN5Dir()
+    mod.run()

--- a/acpreprocessing/stitching_modules/convert_to_n5/acquisition_dir_to_n5_dir.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/acquisition_dir_to_n5_dir.py
@@ -28,7 +28,7 @@ def yield_position_paths_from_rootdir(
 
 
 def get_pixel_resolution_from_rootdir(
-        root_dir, md_bn="acquisition_metadata.json"):
+        root_dir, md_bn="acqinfo_metadata.json"):
     root_path = pathlib.Path(root_dir)
     md_path = root_path / md_bn
     with md_path.open() as f:

--- a/acpreprocessing/stitching_modules/convert_to_n5/tiff_to_n5.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/tiff_to_n5.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python
 
-import ast
 import concurrent.futures
 import dataclasses
 import itertools
 import math
 import pathlib
-from natsort import natsorted
 
 import imageio
+from natsort import natsorted
 import numpy
+import skimage
 
 import z5py
 import argschema
-
-import os
-import shutil
 
 import acpreprocessing.utils.convert
 
 
 def iterate_chunks(it, slice_length):
+    """given an iterator, iterate over tuples of a
+    given length from that iterator
+    """
     it = iter(it)
     chunk = tuple(itertools.islice(it, slice_length))
     while chunk:
@@ -29,6 +29,9 @@ def iterate_chunks(it, slice_length):
 
 
 def iter_arrays(r):
+    """iterate arrays from an imageio tiff reader.  Allows the last image
+    of the array to be None, as is the case for data with 'dropped frames'.
+    """
     for i, p in enumerate(r._tf.pages):
         arr = p.asarray()
         if arr is not None:
@@ -40,6 +43,9 @@ def iter_arrays(r):
 
 
 def iterate_2d_arrays_from_mimgfns(mimgfns):
+    """iterate constituent arrays from an iterator of image filenames
+    that can be opened as an imageio multi-image.
+    """
     for mimgfn in mimgfns:
         print(mimgfn)
         with imageio.get_reader(mimgfn, mode="I") as r:
@@ -47,6 +53,9 @@ def iterate_2d_arrays_from_mimgfns(mimgfns):
 
 
 def iterate_numpy_chunks_from_mimgfns(mimgfns, slice_length=None, pad=True):
+    """iterate over a contiguous iterator of imageio multi-image files as
+    chunks of numpy arrays
+    """
     array_gen = iterate_2d_arrays_from_mimgfns(mimgfns)
     for chunk in iterate_chunks(array_gen, slice_length):
         arr = numpy.array(chunk)
@@ -62,14 +71,27 @@ def iterate_numpy_chunks_from_mimgfns(mimgfns, slice_length=None, pad=True):
             yield arr
 
 
-def mimg_shape_from_fn(mimg_fn):
+def mimg_shape_from_fn(mimg_fn, only_length_tup=False):
+    """get the shape of an imageio multi-image file without
+    reading it as a volume
+    """
     with imageio.get_reader(mimg_fn, mode="I") as r:
-        s = (r.get_length(), *r.get_data(0).shape)
+        if only_length_tup:
+            s = (r.get_length(),)
+        else:
+            s = (r.get_length(), *r.get_data(0).shape)
     return s
 
 
-def joined_mimg_shape_from_fns(mimg_fns):
-    shapes = [mimg_shape_from_fn(fn) for fn in mimg_fns]
+def joined_mimg_shape_from_fns(mimg_fns, concurrency=1):
+    """concurrently read image shapes from tiff files representing a
+    contiguous stack to get the shape of the combined stack.
+    """
+    # join shapes while reading concurrently
+    with concurrent.futures.ThreadPoolExecutor(max_workers=concurrency) as e:
+        futs = [e.submit(mimg_shape_from_fn, fn) for fn in mimg_fns]
+        shapes = [fut.result() for fut
+                  in concurrent.futures.as_completed(futs)]
     return (
         sum([s[0] for s in shapes]),
         shapes[0][1],
@@ -77,11 +99,101 @@ def joined_mimg_shape_from_fns(mimg_fns):
     )
 
 
+def array_downsample_chunks(arr, ds_factors, block_shape, **kwargs):
+    """downsample a numpy array by inputting subvolumes
+    to acpreprocessing.utils.convert.downsample_stack_volume
+    """
+    blocks = skimage.util.view_as_blocks(arr, block_shape)
+
+    # construct output array and blocks
+    output_shape = tuple(
+        int(math.ceil(s / f)) for s, f in zip(arr.shape, ds_factors))
+    output_block_shape = tuple(
+        int(math.ceil(s / f)) for s, f in zip(block_shape, ds_factors))
+    output_arr = numpy.empty(output_shape, dtype=arr.dtype)
+    output_blocks = skimage.util.view_as_blocks(
+        output_arr, output_block_shape)
+
+    # process
+    for idxs in numpy.ndindex(blocks.shape[:arr.ndim]):
+        output_blocks[idxs] = (
+            acpreprocessing.utils.convert.downsample_stack_volume(
+                blocks[idxs], ds_factors, **kwargs))
+
+    return output_arr
+
+
+def array_downsample_threaded(arr, ds_factors, block_shape,
+                              n_threads=3, **kwargs):
+    """downsample a numpy array by concurrently inputting subvolumes
+    to acpreprocessing.utils.convert.downsample_stack_volume
+    """
+    blocks = skimage.util.view_as_blocks(arr, block_shape)
+
+    # construct output array and blocks
+    output_shape = tuple(
+        int(math.ceil(s / f)) for s, f in zip(arr.shape, ds_factors))
+    output_block_shape = tuple(
+        int(math.ceil(s / f)) for s, f in zip(block_shape, ds_factors))
+    output_arr = numpy.empty(output_shape, dtype=arr.dtype)
+    output_blocks = skimage.util.view_as_blocks(
+        output_arr, output_block_shape)
+
+    # process
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n_threads) as e:
+        fut_to_idxs = {}
+        for idxs in numpy.ndindex(blocks.shape[:arr.ndim]):
+            fut_to_idxs[e.submit(
+                acpreprocessing.utils.convert.downsample_stack_volume,
+                blocks[idxs], ds_factors, **kwargs)] = idxs
+
+        for fut in concurrent.futures.as_completed(fut_to_idxs.keys()):
+            idxs = fut_to_idxs[fut]
+            output_blocks[idxs] = fut.result()
+    return output_arr
+
+
+class ArrayChunkingError(ValueError):
+    """ValueError caused by incorrect array chunking"""
+
+
+def downsample_array(arr, *args, n_threads=None, block_shape=None,
+                     block_divs=None, allow_failover=True, **kwargs):
+    """downsample array with optional subvolume chunking and threading
+    """
+    try:
+        if block_shape is not None or block_divs is not None:
+            if block_shape is None:
+                block_shape = [a_s / d for a_s, d in zip(
+                    arr.shape, block_divs)]
+                if not all([s.is_integer() for s in block_shape]):
+                    raise ArrayChunkingError(
+                        "cannot divide array of shape {} by {}".format(
+                            arr.shape, block_divs))
+                block_shape = tuple(int(s) for s in block_shape)
+            if n_threads is not None:
+                return array_downsample_threaded(
+                    arr, *args, n_threads=n_threads,
+                    block_shape=block_shape, **kwargs)
+            return array_downsample_chunks(
+                arr, *args, block_shape=block_shape, **kwargs)
+    except ArrayChunkingError:
+        if not allow_failover:
+            raise
+    return acpreprocessing.utils.convert.downsample_stack_volume(
+        arr, *args, **kwargs)
+
+
 def mip_level_shape(lvl, lvl_0_shape):
+    """get the expected shape of a MIP level downsample for a given
+    full resolution shape
+    """
     return tuple([*map(lambda x: math.ceil(x / (2**lvl)), lvl_0_shape)])
 
 
 def dswrite_chunk(ds, start, end, arr):
+    """write an axis=0 subvolume array into a larger array
+    """
     ds[start:end, :, :] = arr[:(end - start), :, :]
 
 
@@ -94,12 +206,13 @@ class MIPArray:
 
 
 def iterate_mip_levels_from_mimgfns(
-        mimgfns, lvl, block_size,
-        downsample_factor, downsample_method=None):
+        mimgfns, lvl, block_size, downsample_factor,
+        downsample_method=None, lvl_to_mip_kwargs=None):
+    """recursively generate MIPmap levels from an iterator of multi-image files
     """
-    iterator that uses temporary arrays to generate downsample MIP levels as
-      higher resoulution data is read in.  Currently pretty use-case specific.
-    """
+    lvl_to_mip_kwargs = ({} if lvl_to_mip_kwargs is None
+                         else lvl_to_mip_kwargs)
+    mip_kwargs = lvl_to_mip_kwargs.get(lvl, {})
     start_index = 0
     if lvl > 0:
         num_chunks = downsample_factor[0]
@@ -107,7 +220,8 @@ def iterate_mip_levels_from_mimgfns(
         i = 0
         for ma in iterate_mip_levels_from_mimgfns(
                 mimgfns, lvl-1, block_size,
-                downsample_factor, downsample_method):
+                downsample_factor, downsample_method,
+                lvl_to_mip_kwargs):
             chunk = ma.array
             # throw array up for further processing
             yield ma
@@ -134,12 +248,11 @@ def iterate_mip_levels_from_mimgfns(
                 temp_lminus1_arr = temp_lminus1_arr[
                     :block_offset+chunk_size, :, :]
 
-            # yield the full chunk when completed
             if i == num_chunks - 1:
                 temp_arr = (
-                    acpreprocessing.utils.convert.downsample_stack_volume(
-                        temp_lminus1_arr, downsample_factor,
-                        dtype=chunk.dtype, method=downsample_method))
+                    downsample_array(
+                        temp_lminus1_arr, downsample_factor, dtype=chunk.dtype,
+                        method=downsample_method, **mip_kwargs))
                 end_index = start_index + temp_arr.shape[0]
                 yield MIPArray(lvl, temp_arr, start_index, end_index)
                 start_index += temp_arr.shape[0]
@@ -148,7 +261,6 @@ def iterate_mip_levels_from_mimgfns(
                 i += 1
         # add any leftovers
         if i > 0:
-            # FIXME this might be assuming 2x downsample
             temp_arr = acpreprocessing.utils.convert.downsample_stack_volume(
                 temp_lminus1_arr, downsample_factor, dtype=chunk.dtype,
                 method=downsample_method)
@@ -164,94 +276,128 @@ def iterate_mip_levels_from_mimgfns(
 
 
 def write_mimgfns_to_n5(
-        mimgfns, out_n5, ds_name, chunk_size=(64, 64, 64),
-        max_mip=0, mip_dsfactor=(2, 2, 2), concurrency=1,
-        compression="raw"):
-    # TODO different chunk sizes for different levels
-    joined_shapes = joined_mimg_shape_from_fns(mimgfns)
+        mimgfns, output_n5, group_names, group_attributes=None, max_mip=0,
+        mip_dsfactor=(2, 2, 2), chunk_size=(64, 64, 64),
+        concurrency=10, slice_concurrency=1,
+        compression="raw", dtype="uint16", lvl_to_mip_kwargs=None):
+    """write a stack represented by an iterator of multi-image files as an n5
+    volume
+    """
+    group_attributes = ([] if group_attributes is None else group_attributes)
+
+    joined_shapes = joined_mimg_shape_from_fns(
+        mimgfns, concurrency=concurrency)
     # TODO also get dtype from mimg
-    dtype = "uint16"
+
     slice_length = chunk_size[0]
 
-    with z5py.File(out_n5) as f:
+    workers = concurrency // slice_concurrency
+
+    with z5py.File(output_n5) as f:
         mip_ds = {}
-        for mip_lvl in range(max_mip+1):
-            g_lvl = f.create_group(f"s{mip_lvl}")
-            ds_lvl = g_lvl.create_dataset(
-                ds_name,
+        # create groups with custom attributes
+        group_objs = []
+        for i, group_name in enumerate(group_names):
+            try:
+                g = group_objs[-1].create_group(f"{group_name}")
+            except IndexError:
+                g = f.create_group(f"{group_name}")
+            group_objs.append(g)
+            try:
+                attributes = group_attributes[i]
+            except IndexError:
+                continue
+            for k, v in attributes.items():
+                g.attrs[k] = v
+        scales = []
+        for mip_lvl in range(max_mip + 1):
+            ds_lvl = g.create_dataset(
+                f"s{mip_lvl}",
                 chunks=chunk_size,
                 shape=mip_level_shape(mip_lvl, joined_shapes),
                 compression=compression,
-                dtype=dtype
-            )
+                dtype=dtype,
+                n_threads=slice_concurrency)
+            dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
+            ds_lvl.attrs["downsamplingFactors"] = dsfactors
             mip_ds[mip_lvl] = ds_lvl
+            scales.append(dsfactors)
+        g.attrs["scales"] = scales
+        group_objs[0].attrs["downsamplingFactors"] = scales
+        group_objs[0].attrs["dataType"] = dtype
 
-        with concurrent.futures.ThreadPoolExecutor(
-                max_workers=concurrency) as e:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
             futs = []
             for miparr in iterate_mip_levels_from_mimgfns(
-                    mimgfns, max_mip, slice_length, mip_dsfactor):
+                    mimgfns, max_mip, slice_length, mip_dsfactor,
+                    lvl_to_mip_kwargs=lvl_to_mip_kwargs):
                 futs.append(e.submit(
-                    dswrite_chunk,
-                    mip_ds[miparr.lvl], miparr.start, miparr.end,
-                    miparr.array))
+                    dswrite_chunk, mip_ds[miparr.lvl],
+                    miparr.start, miparr.end, miparr.array))
             for fut in concurrent.futures.as_completed(futs):
                 _ = fut.result()
 
 
-class TiffDirToN5InputParameters(argschema.ArgSchema):
-    input_dir = argschema.fields.InputDir(required=True)
-    out_n5 = argschema.fields.Str(required=True)
-    ds_name = argschema.fields.Str(required=True)
+def tiffdir_to_n5_group(tiffdir, *args, **kwargs):
+    mimgfns = [str(p) for p in natsorted(
+                   pathlib.Path(tiffdir).iterdir(), key=lambda x:str(x))
+               if p.is_file()]
+    return write_mimgfns_to_n5(mimgfns, *args, **kwargs)
+
+
+class DownsampleOptions(argschema.schemas.DefaultSchema):
+    block_divs = argschema.fields.List(
+        argschema.fields.Int, required=False, allow_none=True)
+    n_threads = argschema.fields.Int(required=False, allow_none=True)
+
+
+class N5GenerationParameters(argschema.schemas.DefaultSchema):
     max_mip = argschema.fields.Int(required=False, default=0)
     concurrency = argschema.fields.Int(required=False, default=10)
     compression = argschema.fields.Str(required=False, default="raw")
+    lvl_to_mip_kwargs = argschema.fields.Dict(
+        keys=argschema.fields.Int(),
+        values=argschema.fields.Nested(DownsampleOptions))
 
     # FIXME argschema supports lists and tuples,
     #   but has some version differences
-    chunk_size = argschema.fields.Str(required=False, default="64,64,64")
-    mip_dsfactor = argschema.fields.Str(required=False, default="2,2,2")
+    chunk_size = argschema.fields.Tuple((
+        argschema.fields.Int(),
+        argschema.fields.Int(),
+        argschema.fields.Int()), required=False, default=(64, 64, 64))
+    mip_dsfactor = argschema.fields.Tuple((
+        argschema.fields.Int(),
+        argschema.fields.Int(),
+        argschema.fields.Int()), required=False, default=(2, 2, 2))
+
+
+class N5GroupGenerationParameters(N5GenerationParameters):
+    group_names = argschema.fields.List(
+        argschema.fields.Str, required=True)
+    group_attributes = argschema.fields.List(
+        argschema.fields.Dict(required=False, default={}), default=[],
+        required=False)
+
+
+class TiffDirToN5InputParameters(argschema.ArgSchema,
+                                 N5GroupGenerationParameters):
+    input_dir = argschema.fields.InputDir(required=True)
+    out_n5 = argschema.fields.Str(required=True)
 
 
 class TiffDirToN5(argschema.ArgSchemaParser):
     default_schema = TiffDirToN5InputParameters
 
     def run(self):
-        # FIXME this line should work?
-        # mimgfns = [str(p) for p in natsorted(pathlib.Path(self.args["input_dir"]).iterdir(), key=lambda x:str(p)) if p.is_file()]
-        files = [*sorted(pathlib.Path(self.args["input_dir"]).iterdir())]
-        mimgfns = natsorted([str(p) for p in files if p.name.endswith('.tif')])
-        
-        # FIXME argschema can and should do this
-        chunk_size = ast.literal_eval(self.args["chunk_size"])
-        mip_dsfactor = ast.literal_eval(self.args["mip_dsfactor"])
-
-        write_mimgfns_to_n5(
-            mimgfns, self.args["out_n5"], self.args["ds_name"],
-            chunk_size, self.args["max_mip"], mip_dsfactor,
-            self.args["concurrency"], self.args["compression"])
-
-        # Fix dir structure
-        multires = os.path.join(self.args["out_n5"],
-                                "multires"+self.args["ds_name"])
-
-        fullres = os.path.join(self.args["out_n5"], "s0/"+self.args["ds_name"])
-        shutil.move(fullres, self.args["out_n5"])
-
-        try:
-            os.rmdir(os.path.join(self.args["out_n5"], "s0"))
-        except OSError as e:
-            print("Error: %s : %s" % (dir_path, e.strerror))
-
-        os.makedirs(multires)
-        for mip_level in range(1, self.args["max_mip"]+1):
-            source = os.path.join(self.args["out_n5"], os.path.join(
-                            f"s{mip_level}/", self.args["ds_name"]))
-            shutil.move(source, os.path.join(multires, f"s{mip_level}"))
-            try:
-                os.rmdir(os.path.join(self.args["out_n5"], f"s{mip_level}"))
-            except OSError as e:
-                print("Error: %s : %s" % (dir_path, e.strerror))
+        tiffdir_to_n5_group(
+            self.args["input_dir"], self.args["out_n5"],
+            self.args["group_names"], self.args["group_attributes"],
+            self.args["max_mip"],
+            self.args["mip_dsfactor"],
+            self.args["chunk_size"],
+            concurrency=self.args["concurrency"],
+            compression=self.args["compression"],
+            lvl_to_mip_kwargs=self.args["lvl_to_mip_kwargs"])
 
 
 if __name__ == "__main__":

--- a/acpreprocessing/stitching_modules/convert_to_n5/tiff_to_n5.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/tiff_to_n5.py
@@ -191,9 +191,9 @@ def mip_level_shape(lvl, lvl_0_shape):
     return tuple([*map(lambda x: math.ceil(x / (2**lvl)), lvl_0_shape)])
 
 
-def dswrite_chunk(ds, start, end, arr):
-    """write an axis=0 subvolume array into a larger array
-    """
+def dswrite_chunk(ds, start, end, arr, silent_overflow=True):
+    if end >= ds.shape[0] and silent_overflow:
+        end = ds.shape[0]
     ds[start:end, :, :] = arr[:(end - start), :, :]
 
 


### PR DESCRIPTION
This is kind of a doozy.
Introduces `acpreprocessing.stitching_modules.convert_to_n5.acquisition_dir_to_n5`, which facilitates the process of writing an acquisition tiff dir (from the halohalo format) to an n5 directory, meaning that you should rarely have to call `tiff_to_n5` directly.

Also modifies the n5 generation script in a couple of ways:
- z5py writes the metadata attributes rather than post-hoc json updates
- the group/dataset structure is consistent with the expectation from neuroglancer and bigdataviewer (previously this was accomplished with some moves and symlinking)
- adds concurrency arguments in a few places (e.g. reading file metadata)
- introduces options to "chunk" the downsampling process.  In some tests, this reduces time to downsample significantly, but is turned off by default.