### PR TITLE
tiff_to_n5: add missing offset for interleaving iterator

### DIFF
--- a/acpreprocessing/stitching_modules/convert_to_n5/tiff_to_n5.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/tiff_to_n5.py
@@ -61,7 +61,7 @@ def iter_arrays(r, interleaved_channels=1, channel=0, interleaving_offset=0):
         constituent page array of reader r
     """
     for i, p in enumerate(r._tf.pages):
-        page_channel = (i - interleaving_offset) % interleaved_channels
+        page_channel = (i + interleaving_offset) % interleaved_channels
         if page_channel != channel:
             continue
         arr = p.asarray()


### PR DESCRIPTION
# Description

bugfix adding uncommitted code for tiff_to_n5 dealing with tiff files of lengths not evenly divisible by the number of interleaved channels

## Type of change
<!-- Please copy one of the commented-out lines below to describe the scope of this change -->
Bug Fix (non-breaking change fixing unexpected behavior)


## Checklist
- [ ] Modified code is covered in tests (currently not required)
- [x] PR is based on correct branch (this is likely `develop`)
- [x] Code is pep8 compliant
- [x] New methods have NumpyDoc compliant docstrings
