### PR TITLE
requirements: imageio less than 2.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pillow
 tifffile==2020.7.4
 scikit-image
 numpy
-imageio
+imageio<2.21
 matplotlib
 argschema
 natsort


### PR DESCRIPTION
# Description

imageio 2.21 breaks actiff format writing (and associated tests) -- this adds a version constraint to requirements.txt


## Type of change
<!-- Please copy one of the commented-out lines below to describe the scope of this change -->
Bug Fix (non-breaking change fixing unexpected behavior)

<!--
Bug Fix (non-breaking change fixing unexpected behavior)
New Feature (non-breaking change adding functionality)
Breaking change (fix or feature which may break existing functionality)
Maintenance (Minimal functionality changes e.g. documentation, formatting, adding tests)
-->

## Checklist
- [x] Modified code is covered in tests (currently not required)
- [x] PR is based on correct branch (this is likely `develop`)
- [x] Code is pep8 compliant
- [x] New methods have NumpyDoc compliant docstrings
