### PR TITLE
config: add flake8 options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,10 @@ python =
 [coverage:run]
 omit = test/*
 
+[flake8]
+ignore = E226,E126,E741
+max-line-length = 79
+
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
# Description

Adds flake8 ignores for the following:
E226 -- missing whitespace around arithmetic operator
E126 -- continuation line over-indented for hanging indent
E741 -- do not use variables named ‘l’, ‘O’, or ‘I’

as these are not strictly included in PEP8 and are ones I personally find the most bothersome.  I am open to all the standard exceptions as well (see pycodestyle docs https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes)


## Type of change
<!-- Please copy one of the commented-out lines below to describe the scope of this change -->
<!--
Bug Fix (non-breaking change fixing unexpected behavior)
New Feature (non-breaking change adding functionality)
Breaking change (fix or feature which may break existing functionality)
Maintenance (Minimal functionality changes e.g. documentation, formatting, adding tests)
-->
Maintenance (Minimal functionality changes e.g. documentation, formatting, adding tests)


## Checklist
- ~~[ ] Modified code is covered in tests (currently not required)~~
- [x] PR is based on correct branch (this is likely `develop`)
- ~~[ ] Code is pep8 compliant~~
- ~~[ ] New methods have NumpyDoc compliant docstrings~~
