### PR TITLE
Zarr v3 deskew and conversion for new Exaspim acquisitions

### DIFF
--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -413,19 +413,8 @@ def write_zarrv3_to_zarr(
         scales = []
         
         for mip_lvl in range(max_mip + 1):
-            # ds_lvl = g.create_dataset(
-            #     f"{mip_lvl}",
-            #     chunks=chunk_size,
-            #     shape=mip_level_shape(mip_lvl, joined_shapes),
-            #     compression=compression,
-            #     dtype=dtype,
-            #     n_threads=slice_concurrency)
-            # dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
-            # ds_lvl.attrs["downsamplingFactors"] = dsfactors
-            # mip_ds[mip_lvl] = ds_lvl
-            # scales.append(dsfactors)
-            if not str(mip_lvl) in g:
-                mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
+            mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
+            try:
                 ds_lvl = g.create_dataset(
                     f"{mip_lvl}",
                     chunks=chunk_size,
@@ -433,7 +422,7 @@ def write_zarrv3_to_zarr(
                     compression=compression,
                     dtype=dtype
                 )
-            else:
+            except ValueError:
                 ds_lvl = g[str(mip_lvl)]
             dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
             mip_ds[mip_lvl] = ds_lvl

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -423,7 +423,7 @@ def write_zarrv3_to_zarr(
         
         nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
         print(str(nblocks) + " number of chunks per axis")
-        print(str(g[0].nchunks) + " chunk number sanity check")
+        #print(str(g[0].nchunks) + " chunk number sanity check")
     
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
             futs = []

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -468,8 +468,6 @@ class Zarrv3ToZarrInputParameters(argschema.ArgSchema,
     chunk_size = argschema.fields.Tuple((
         argschema.fields.Int(),
         argschema.fields.Int(),
-        argschema.fields.Int(),
-        argschema.fields.Int(),
         argschema.fields.Int()), required=False, default=(64, 64, 64))
 
 

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -435,7 +435,7 @@ def zarrv3_to_ngff_group(zarr_fn, output, *args, block_cc=1, chunknum=-1, **kwar
             numblocks = calculate_blocks(zshape,**kwargs)
             with concurrent.futures.ProcessPoolExecutor(max_workers=block_cc) as e:
                 futs = []
-                for n in [4,5]:#range(numblocks):
+                for n in range(numblocks):
                     futs.append(e.submit(write_zarrv3_to_zarr,zarr_fn,*args,slice_concurrency=block_cc, chunknum=n, **kwargs))
                     sleep(1)
                 for fut in concurrent.futures.as_completed(futs):

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python
+
+import concurrent.futures
+import dataclasses
+#import itertools
+# import math
+#import pathlib
+
+# import imageio
+#from natsort import natsorted
+import numpy
+# import skimage
+
+import zarr
+from numcodecs import Blosc
+import argschema
+
+import acpreprocessing.stitching_modules.convert_to_n5.psdeskew as psd
+from acpreprocessing.stitching_modules.convert_to_n5.tiff_to_ngff import downsample_array,mip_level_shape,omezarr_attrs,NGFFGroupGenerationParameters,TiffToNGFFValueError
+
+
+@dataclasses.dataclass
+class MIPArray:
+    lvl: int
+    array: numpy.ndarray
+    start: tuple # list of indices (int)
+    end: tuple # list of indices (int)
+
+
+def dswrite_block(ds, start, end, arr, silent_overflow=True):
+    """write array arr into array-like n5 dataset defined by
+    start and end point 3-tuples.
+
+    Parameters
+    ----------
+    ds : z5py.dataset.Dataset (n5 3D) or zarr.dataset (zarr 5D)
+        array-like dataset to fill in
+    start : tuple[int]
+        start index along 0 axis of ds to fill in
+    end : tuple[int]
+        end index along 0 axis of ds to fill in
+    arr : numpy.ndarray
+        array from which ds values will be taken
+    silent_overflow : bool, optional
+        whether to shrink the end index to match the
+        shape of ds (default: True)
+    """
+    start = list(start)
+    end = list(end)
+    if len(ds.shape) == 5:  # dataset dimensions should be 3 or 5
+        for i in range(3):
+            if end[i] >= ds.shape[2+i] and silent_overflow:
+                end[i] = ds.shape[2+i]
+        #if end > start:
+        ds[0, 0, start[0]:end[0], start[1]:end[1], start[2]:end[2]] = arr[:(end[0] - start[0]), :(end[1] - start[1]), :(end[2] - start[2])]
+    elif len(ds.shape) == 3:
+        for i in range(3):    
+            if end[i] >= ds.shape[i] and silent_overflow:
+                end[i] = ds.shape[i]
+        #if end > start:
+        ds[start[0]:end[0], start[1]:end[1], start[2]:end[2]] = arr[:(end[0] - start[0]), :(end[1] - start[1]), :(end[2] - start[2])]
+
+
+def write_mips(zgrp,miparrs):
+    for miparr in miparrs:
+        dswrite_block(ds=zgrp[miparr.lvl],start=miparr.start,end=miparr.end,arr=miparr.array)
+
+
+def iterate_numpy_blocks_from_dataset(
+        dataset, nblocks, chunknum=-1, block_size=None, pad=True, deskew_kwargs={}, *args, **kwargs):
+    """iterate over a contiguous hdf5 daataset as chunks of numpy arrays
+
+    Parameters
+    ----------
+    dataset : hdf5 dataset
+        imageio-compatible name inputs to be opened as multi-images
+    nblocks : tuple[int]
+        number of 2d arrays from mimgfns included per chunk
+    pad : bool, optional
+        whether to extend final returned chunks with zeros
+
+    Yields
+    ------
+    arr : numpy.ndarray
+        3D numpy array representing a consecutive chunk of 2D arrays
+    """
+    
+    nchunks = nblocks
+    test = False
+    dshape = dataset.shape
+    if deskew_kwargs:
+        # calculate input data chunk dims based on output block dims
+        chunk_size = (deskew_kwargs["chunklength"],block_size[1],block_size[2]*deskew_kwargs["stride"])
+        if deskew_kwargs["transpose"]:
+            # transpose dims if needed
+            chunk_size = (chunk_size[0],chunk_size[2],chunk_size[1])
+            dshape = (dshape[0],dshape[2],dshape[1])
+        print("chunk size: " + str(chunk_size))
+    for i in range(numpy.prod(nchunks)):
+        chunk_tuple = numpy.unravel_index(i,tuple(nchunks),order='F')
+        if chunknum >= 0:
+            chunk_is_ok = (chunk_tuple[2] == chunknum)
+        else:
+            chunk_is_ok = True
+        if chunk_is_ok:
+            if test:
+                chunk_tuple = (chunk_tuple[0], chunk_tuple[1], chunknum)
+            # deskew level 0 data blocks
+            if deskew_kwargs:
+                if deskew_kwargs["transpose"]:
+                    chunk_tuple = (chunk_tuple[0],chunk_tuple[2],chunk_tuple[1])
+                print(str(chunk_tuple))
+                if chunk_tuple[0] == 0:
+                    chunk_index = 0
+                    deskew_kwargs["slice1d"][...] = 0
+                    if test:
+                        first_z = 0
+                        first_slice = 0
+                    else:
+                        if not deskew_kwargs["flip"]:
+                            x_index = chunk_tuple[1]
+                        else:
+                            x_index = nblocks[2] - chunk_tuple[1] - 1
+                        first_z,first_slice = psd.calculate_first_chunk(chunk_size=chunk_size,x_index=x_index,stride=deskew_kwargs["stride"])
+                    print(str(first_z) + "," + str(first_slice))
+                if chunk_tuple[0] < first_z or chunk_tuple[0]*chunk_size[0] - first_slice >= dshape[0]:
+                    arr = numpy.zeros(block_size,dtype=dataset.dtype)
+                else:
+                    chunk_start = numpy.array([t*s for t,s in zip(chunk_tuple,chunk_size)])
+                    chunk_end = chunk_start + numpy.array(chunk_size)
+                    if chunk_start[0] < first_slice:
+                        chunk_end[0] = chunk_size[0] - (first_slice - chunk_start[0])
+                        chunk = numpy.zeros(chunk_size,dtype=dataset.dtype)
+                        zdata = numpy.asarray(dataset[:chunk_end[0],chunk_start[1]:chunk_end[1],chunk_start[2]:chunk_end[2]])
+                        print("data dimension is " + str(zdata.shape) + " max is " + str(numpy.max(zdata)))
+                        chunk[first_slice-chunk_start[0]:] = zdata
+                    else:
+                        chunk_start[0] -= first_slice
+                        chunk_end[0] -= first_slice
+                        print(str(chunk_start[0]))
+                        zdata = numpy.asarray(dataset[chunk_start[0]:chunk_end[0],chunk_start[1]:chunk_end[1],chunk_start[2]:chunk_end[2]])
+                        print("data dimension is " + str(zdata.shape) + " max is " + str(numpy.max(zdata)))
+                        chunk = zdata
+                    if any([sh<sz for sh,sz in zip(chunk.shape,chunk_size)]):
+                        print(str(chunk.shape) + " is small for" + str(chunk_size) + ": filling with zeros")
+                        temp_chunk = numpy.zeros(chunk_size,dtype=chunk.dtype)
+                        temp_chunk[:chunk.shape[0],:chunk.shape[1],:chunk.shape[2]] = chunk
+                        chunk = temp_chunk
+                    if deskew_kwargs["transpose"]:
+                        chunk = chunk.transpose((0,2,1))
+                    arr = numpy.flip(
+                        numpy.transpose(
+                            psd.deskew_block(
+                                chunk,
+                                chunk_index,
+                                **deskew_kwargs), 
+                            (2, 1, 0)),
+                        axis=2)
+                chunk_index += 1
+            else:
+                if chunk_tuple[0] == 0:
+                    print(str(chunk_tuple))
+                block_start = [chunk_tuple[k]*block_size[k] for k in range(3)]
+                block_end = [block_start[k] + block_size[k] for k in range(3)]
+                arr = numpy.asarray(dataset[block_start[0]:block_end[0],block_start[1]:block_end[1],block_start[2]:block_end[2]])
+            if any([arr.shape[k] != block_size[k] for k in range(3)]):
+                print(str(arr.shape) + "is small for " + str(block_size))
+                if pad:
+                    newarr = numpy.zeros(block_size,
+                                          dtype=arr.dtype)
+                    newarr[:arr.shape[0], :arr.shape[1], :arr.shape[2]] = arr[:, :, :]
+                    yield i,newarr
+                else:
+                    yield i,arr
+            else:
+                yield i,arr
+        else:
+            yield i,None
+
+
+def iterate_mip_levels_from_dataset(
+        dataset, lvl, maxlvl, nblocks, block_size, downsample_factor,
+        chunknum=-1,downsample_method=None, lvl_to_mip_kwargs=None,
+        interleaved_channels=1, channel=0, deskew_kwargs={}):
+    """recursively generate MIPmap levels from an iterator of blocks
+
+    Parameters
+    ----------
+    dataset : hdf5 dataset
+        imageio-compatible name inputs to be opened as multi-images
+    lvl : int
+        integer mip level to generate
+    block_size : int
+        number of 2D arrays in chunk to process for a chunk at lvl
+    slice_length : int
+        number of 2D arrays to gather from tiff stacks
+    downsample_factor : tuple of int
+        integer downsampling factor for MIP levels
+    downsample_method : str, optional
+        downsampling method for
+        acpreprocessing.utils.convert.downsample_stack_volume
+    lvl_to_mip_kwargs :  dict, optional
+        mapping of MIP level to kwargs used in MIPmap generation
+    interleaved_channels : int
+        number of channels interleaved in the tiff files (default 1)
+    channel : int, optional
+        channel from which interleaved data should be read (default 0)
+    deskew_kwargs : dict, optional
+        parameters for pixel shifting deskew
+
+    Yields
+    ------
+    ma : acpreprocessing.stitching_modules.convert_to_n5.tiff_to_n5.MipArray
+        object describing chunked array, MIP level of origin, and chunk indices
+    """
+    lvl_to_mip_kwargs = ({} if lvl_to_mip_kwargs is None
+                          else lvl_to_mip_kwargs)
+    mip_kwargs = lvl_to_mip_kwargs.get(lvl, {})
+    # block_index = 0
+    # if num_slice == 1:
+    #     block_index = nblocks[0]*nblocks[1]*chunknum
+    if lvl > 0:
+        for ma in iterate_mip_levels_from_dataset(
+                dataset, lvl-1, maxlvl, nblocks, block_size,
+                downsample_factor, chunknum, downsample_method,
+                lvl_to_mip_kwargs, interleaved_channels=interleaved_channels,
+                channel=channel, deskew_kwargs=deskew_kwargs):
+            chunk = ma.array
+            # throw array up for further processing
+            yield ma
+            # ignore if not parent resolution
+            if ma.lvl != lvl-1:
+                continue
+            
+            temp_arr = (downsample_array(
+                    chunk, downsample_factor, dtype=chunk.dtype,
+                    method=downsample_method, **mip_kwargs))
+            chunk_start = tuple(int(ma.start[k]/downsample_factor[k]) for k in range(3))
+            chunk_end = tuple(chunk_start[k] + temp_arr.shape[k] for k in range(3))
+            yield MIPArray(lvl, temp_arr, chunk_start, chunk_end)
+    else:
+        # get level 0 chunks
+        # block_size is the number of slices to read from tiffs
+        for block_index,block in iterate_numpy_blocks_from_dataset(
+                dataset, nblocks, chunknum=chunknum, block_size=block_size, pad=False,
+                deskew_kwargs=deskew_kwargs,
+                channel=channel):
+            if not block is None:
+                block_tuple = numpy.unravel_index(block_index,nblocks,order='F')
+                if not deskew_kwargs["flip"]:
+                    block_tuple = (block_tuple[0],block_tuple[1],nblocks[2] - block_tuple[2] - 1)
+                block_start = tuple(block_tuple[k]*block_size[k] for k in range(3))
+                block_end = tuple(block_start[k] + block.shape[k] for k in range(3))
+                yield MIPArray(lvl, block, block_start, block_end)
+            # block_index += 1
+
+
+def write_zarrv3_to_zarr(
+        zarr_fn, output_n5, group_names, group_attributes=None, max_mip=0,
+        mip_dsfactor=(2, 2, 2), chunk_size=(1, 1, 64, 64, 64),
+        concurrency=10, slice_concurrency=1, block_size=(512,512,512),
+        compression="raw", dtype="uint16", lvl_to_mip_kwargs=None,
+        interleaved_channels=1, channel=0, deskew_options=None, chunknum=-1, **kwargs):
+    """write a stack represented by an iterator of multi-image files as a zarr
+    volume with ome-ngff metadata
+
+    Parameters
+    ----------
+    zarr_fn : str
+        imageio-compatible name inputs to be opened as multi-images
+    output_n5 : str
+        output zarr directory
+    group_names : list of str
+        names of groups to generate within n5
+    group_attributes : list of dict, optional
+        attribute dictionaries corresponding to group with matching index
+    max_mip : int
+        maximum MIP level to generate
+    mip_dsfactor : tuple of int
+        integer downsampling factor for MIP levels
+    chunk_size : tuple of int
+        chunk size for n5 datasets
+    concurrency : int
+        total concurrency used for writing arrays to n5
+        (python threads = concurrency // slice_concurrency)
+    slice_concurrency : int
+        threads used by z5py
+    compression : str, optional
+        compression for n5 (default: raw)
+    dtype : str, optional
+        dtype for n5 (default: uint16)
+    lvl_to_mip_kwargs :  dict, optional
+        mapping of MIP level to kwargs used in MIPmap generation
+    interleaved_channels : int
+        number of channels interleaved in the tiff files (default 1)
+    channel : int, optional
+        channel from which interleaved data should be read (default 0)
+    deskew_options : dict, optional
+        dictionary of parameters to run pixel shifting deskew (default None)
+    """
+    group_attributes = ([] if group_attributes is None else group_attributes)
+    deskew_options = ({} if deskew_options is None else deskew_options)
+    
+    zs = zarr.open(zarr_fn)
+    zarray = zs['0']
+    zarr_chunk_size = zarray.chunks
+    print("zarr chunks: " + str(zarr_chunk_size))
+    print("deskewed block size: " + str(block_size))
+    
+    joined_shapes = zarray.shape
+    if deskew_options and deskew_options["deskew_transpose"]:
+        # input dataset must be transposed
+        joined_shapes = (joined_shapes[0],joined_shapes[2],joined_shapes[1])
+    print("ims_to_ngff dataset shape:" + str(joined_shapes))
+
+    if deskew_options and deskew_options["deskew_method"] == "ps":
+        print(deskew_options)
+        if not deskew_options["deskew_stride"] is None:
+            stride = deskew_options["deskew_stride"]
+        else:
+            stride = 1
+        slice_length = int(block_size[0]/stride)
+        deskew_kwargs = psd.psdeskew_kwargs(skew_dims_zyx=(slice_length, block_size[1], block_size[2]*stride), # size of skewed chunk to iterate for deskewed block
+                                            **deskew_options)
+        joined_shapes = psd.reshape_joined_shapes(
+            joined_shapes, stride, block_size)# transpose=(2,1,0))
+        print("deskewed shape:" + str(joined_shapes))
+    else:
+        deskew_kwargs = {}
+
+    # TODO DESKEW: does this generally work regardless of skew?
+
+    workers = concurrency // slice_concurrency
+
+    zstore = zarr.DirectoryStore(output_n5, dimension_separator='/')
+    with zarr.open(zstore, mode='a') as f:
+        mip_ds = {}
+        # create groups with attributes according to omezarr spec
+        if len(group_names) == 1:
+            group_name = group_names[0]
+            if group_name in f:
+                g = f[f"{group_name}"]
+            else:
+                g = f.create_group(f"{group_name}")
+            # try:
+            #     g = f.create_group(f"{group_name}")
+            # except KeyError:
+            #     g = f[f"{group_name}"]
+                
+            if group_attributes:
+                try:
+                    attributes = group_attributes[0]
+                except IndexError:
+                    print('attributes error')
+            else:
+                attributes = {}
+
+            if "pixelResolution" in attributes:
+                if deskew_options:
+                    attributes["pixelResolution"]["dimensions"][2] /= deskew_options["deskew_stride"]
+                attributes = omezarr_attrs(
+                    group_name, attributes["position"], attributes["pixelResolution"]["dimensions"], max_mip)
+            if attributes:
+                for k, v in attributes.items():
+                    g.attrs[k] = v
+        else:
+            raise TiffToNGFFValueError("only one group name expected")
+        scales = []
+
+        # shuffle=Blosc.BITSHUFFLE)
+        compression = Blosc(cname='zstd', clevel=1)
+        for mip_lvl in range(max_mip + 1):
+            if not mip_lvl in g:
+                mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
+                ds_lvl = g.create_dataset(
+                    f"{mip_lvl}",
+                    chunks=chunk_size,
+                    shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
+                    compression=compression,
+                    dtype=dtype
+                )
+            else:
+                ds_lvl = g[mip_lvl]
+            dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
+            mip_ds[mip_lvl] = ds_lvl
+            scales.append(dsfactors)
+        
+        nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
+        print(str(nblocks) + " number of chunks per axis")
+        print(str(g[0].nchunks) + " chunk number sanity check")
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
+            futs = []
+            mips = []
+            for miparr in iterate_mip_levels_from_dataset(
+                    zarray, max_mip, max_mip, nblocks, block_size, mip_dsfactor,
+                    chunknum=chunknum,
+                    lvl_to_mip_kwargs=lvl_to_mip_kwargs,
+                    interleaved_channels=interleaved_channels,
+                    channel=channel, deskew_kwargs=deskew_kwargs):
+                mips.append(miparr)
+                if miparr.lvl == max_mip:
+                    futs.append(e.submit(
+                        write_mips, mip_ds, mips))
+                    mips = []
+            for fut in concurrent.futures.as_completed(futs):
+                _ = fut.result()
+    print("conversion complete, closing file")
+
+
+def calculate_blocks(dshape,block_size,deskew_options,**kwargs):
+    if deskew_options:
+        transpose = deskew_options["deskew_transpose"]
+        stride = deskew_options["deskew_stride"]
+    else:
+        transpose = False
+        stride = 1
+    if transpose:
+        d = dshape[1]
+    else:
+        d = dshape[2]
+    print(d)
+    return int(numpy.ceil(d/(block_size[2]*stride)))
+
+
+def zarrv3_to_ngff_group(zarr_fn, output, *args, block_cc=1, chunknum=-1, **kwargs):
+    """convert directory of natsort-consecutive multitiffs to an n5 or zarr pyramid
+
+    Parameters
+    ----------
+    tiffdir : str
+        directory of consecutive multitiffs to convert
+    """
+
+    if output == 'zarr':
+        print('converting to zarr')
+        if chunknum > -1:
+            return write_zarrv3_to_zarr(zarr_fn, *args, slice_concurrency=1, chunknum=chunknum, **kwargs)
+        else:
+            with zarr.open(zarr_fn) as zf:
+                zshape = zf['0'].shape
+            numblocks = calculate_blocks(zshape,**kwargs)
+            with concurrent.futures.ProcessPoolExecutor(max_workers=block_cc) as e:
+                futs = []
+                for n in range(numblocks):
+                    futs.append(e.submit(write_zarrv3_to_zarr,zarr_fn,*args,slice_concurrency=block_cc, chunknum=n, **kwargs))
+                for fut in concurrent.futures.as_completed(futs):
+                    _ = fut.result()
+    else:
+        print('unknown output format: ' + output)
+
+
+
+class IMSToNGFFParameters(NGFFGroupGenerationParameters):
+    input_file = argschema.fields.Str(required=True)
+    interleaved_channels = argschema.fields.Int(required=False, default=1)
+    channel = argschema.fields.Int(required=False, default=0)
+    chunk_num = argschema.fields.Int(required=False, default=-1)
+    block_concurrency = argschema.fields.Int(required=False, default=1)
+    block_size = argschema.fields.Tuple((
+        argschema.fields.Int(),
+        argschema.fields.Int(),
+        argschema.fields.Int()), required=False, default=(512,512,512))
+
+
+class Zarrv3ToZarrInputParameters(argschema.ArgSchema,
+                                    IMSToNGFFParameters):
+    chunk_size = argschema.fields.Tuple((
+        argschema.fields.Int(),
+        argschema.fields.Int(),
+        argschema.fields.Int(),
+        argschema.fields.Int(),
+        argschema.fields.Int()), required=False, default=(64, 64, 64))
+
+
+
+class Zarrv3ToZarr(argschema.ArgSchemaParser):
+    default_schema = Zarrv3ToZarrInputParameters
+
+    def run(self):
+        deskew_options = (self.args["deskew_options"]
+                          if "deskew_options" in self.args else {})
+        zarrv3_to_ngff_group(
+            self.args["input_file"], self.args["output_format"],
+            self.args["output_file"], self.args["group_names"],
+            self.args["group_attributes"],
+            self.args["max_mip"],
+            self.args["mip_dsfactor"],
+            self.args["chunk_size"],
+            concurrency=self.args["concurrency"],
+            compression=self.args["compression"],
+            #lvl_to_mip_kwargs=self.args["lvl_to_mip_kwargs"],
+            chunknum = self.args["chunk_num"],
+            block_cc = self.args["block_concurrency"],
+            block_size = self.args["block_size"],
+            deskew_options=deskew_options)
+
+
+
+if __name__ == "__main__":
+    mod = Zarrv3ToZarr()
+    mod.run()

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -341,7 +341,10 @@ def write_zarrv3_to_zarr(
             if group_name in f:
                 g = f[f"{group_name}"]
             else:
-                g = f.create_group(f"{group_name}")
+                try:
+                    g = f.create_group(f"{group_name}")
+                except KeyError:
+                    g = f[f"{group_name}"]
                 
             if group_attributes:
                 try:
@@ -365,7 +368,9 @@ def write_zarrv3_to_zarr(
         
         for mip_lvl in range(max_mip + 1):
             mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
-            if not str(mip_lvl) in g:
+            if str(mip_lvl) in g:
+                ds_lvl = g[str(mip_lvl)]
+            else:
                 try:
                     ds_lvl = g.create_dataset(
                         f"{mip_lvl}",
@@ -374,10 +379,9 @@ def write_zarrv3_to_zarr(
                         compression=compression,
                         dtype=dtype
                     )
-                except:
+                except KeyError:
                     ds_lvl = g[str(mip_lvl)]
-            else:
-                ds_lvl = g[str(mip_lvl)]
+                
             dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
             mip_ds[mip_lvl] = ds_lvl
             scales.append(dsfactors)

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -424,7 +424,7 @@ def write_zarrv3_to_zarr(
             # ds_lvl.attrs["downsamplingFactors"] = dsfactors
             # mip_ds[mip_lvl] = ds_lvl
             # scales.append(dsfactors)
-            if not mip_lvl in g:
+            if not str(mip_lvl) in g:
                 mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
                 ds_lvl = g.create_dataset(
                     f"{mip_lvl}",
@@ -434,7 +434,7 @@ def write_zarrv3_to_zarr(
                     dtype=dtype
                 )
             else:
-                ds_lvl = g[mip_lvl]
+                ds_lvl = g[str(mip_lvl)]
             dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
             mip_ds[mip_lvl] = ds_lvl
             scales.append(dsfactors)

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -333,7 +333,7 @@ def write_zarrv3_to_zarr(
     workers = concurrency // slice_concurrency
     
     # updating for zarr v3 store and array creation
-    zstore = zarr.storage.LocalStore(output_n5, dimension_separator='/')
+    zstore = zarr.storage.LocalStore(output_n5)
     with zarr.open(zstore, mode='a') as f:
         mip_ds = {}
         # create groups with attributes according to omezarr spec

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -2,15 +2,8 @@
 
 import concurrent.futures
 import dataclasses
-#import itertools
-# import math
-#import pathlib
-
-# import imageio
-#from natsort import natsorted
 import numpy
-# import skimage
-
+from time import sleep
 import zarr
 import z5py
 from numcodecs import Blosc
@@ -444,6 +437,7 @@ def zarrv3_to_ngff_group(zarr_fn, output, *args, block_cc=1, chunknum=-1, **kwar
                 futs = []
                 for n in range(numblocks):
                     futs.append(e.submit(write_zarrv3_to_zarr,zarr_fn,*args,slice_concurrency=block_cc, chunknum=n, **kwargs))
+                    sleep(1)
                 for fut in concurrent.futures.as_completed(futs):
                     _ = fut.result()
     else:

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -522,7 +522,9 @@ class Zarrv3ToZarrInputParameters(argschema.ArgSchema,
     chunk_size = argschema.fields.Tuple((
         argschema.fields.Int(),
         argschema.fields.Int(),
-        argschema.fields.Int()), required=False, default=(64, 64, 64))
+        argschema.fields.Int(),
+        argschema.fields.Int(),
+        argschema.fields.Int()), required=False, default=(1, 1, 64, 64, 64))
 
 
 

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -385,29 +385,31 @@ def write_zarrv3_to_zarr(
         #     dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
         #     mip_ds[mip_lvl] = ds_lvl
         #     scales.append(dsfactors)
-        group_objs = []
-        for i, group_name in enumerate(group_names):
+        if len(group_names) == 1:
+            group_name = group_names[0]
             try:
-                g = group_objs[-1].create_group(f"{group_name}")
-            except IndexError:
-                try:
-                    g = f.create_group(f"{group_name}")
-                except KeyError:
-                    g = f[f"{group_name}"]
-            group_objs.append(g)
+                g = f.create_group(f"{group_name}")
+            except KeyError:
+                g = f[f"{group_name}"]
             try:
-                attributes = group_attributes[i]
+                attributes = group_attributes[0]
             except IndexError:
-                continue
-            if deskew_options:
-                if "pixelResolution" in attributes:
-                    attributes["pixelResolution"]["dimensions"][0] /= deskew_options["deskew_stride"]
-            for k, v in attributes.items():
-                g.attrs[k] = v
+                print('attributes error')
+
+            if "pixelResolution" in attributes:
+                if deskew_options:
+                    attributes["pixelResolution"]["dimensions"][2] /= deskew_options["deskew_stride"]
+                attributes = omezarr_attrs(
+                    group_name, attributes["position"], attributes["pixelResolution"]["dimensions"], max_mip)
+            if attributes:
+                for k, v in attributes.items():
+                    g.attrs[k] = v
+        else:
+            raise TiffToNGFFValueError("only one group name expected")
         scales = []
         for mip_lvl in range(max_mip + 1):
             ds_lvl = g.create_dataset(
-                f"s{mip_lvl}",
+                f"{mip_lvl}",
                 chunks=chunk_size,
                 shape=mip_level_shape(mip_lvl, joined_shapes),
                 compression=compression,
@@ -417,9 +419,6 @@ def write_zarrv3_to_zarr(
             ds_lvl.attrs["downsamplingFactors"] = dsfactors
             mip_ds[mip_lvl] = ds_lvl
             scales.append(dsfactors)
-        g.attrs["scales"] = scales
-        group_objs[0].attrs["downsamplingFactors"] = scales
-        group_objs[0].attrs["dataType"] = dtype
         
         nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
         print(str(nblocks) + " number of chunks per axis")

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -343,7 +343,7 @@ def write_zarrv3_to_zarr(
             else:
                 try:
                     g = f.create_group(f"{group_name}")
-                except KeyError:
+                except:
                     g = f[f"{group_name}"]
                 
             if group_attributes:
@@ -379,7 +379,7 @@ def write_zarrv3_to_zarr(
                         compression=compression,
                         dtype=dtype
                     )
-                except KeyError:
+                except:
                     ds_lvl = g[str(mip_lvl)]
                 
             dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -334,7 +334,7 @@ def write_zarrv3_to_zarr(
     workers = concurrency // slice_concurrency
     
     # updating for zarr v3 store and array creation
-    with z5py.File(output_n5) as f:
+    with z5py.File(output_n5,use_zarr_format=True) as f:
         mip_ds = {}
         # create groups with attributes according to omezarr spec
         # if len(group_names) == 1:

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -377,7 +377,7 @@ def write_zarrv3_to_zarr(
                 f"{mip_lvl}",
                 chunks=chunk_size,
                 shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
-                compression=compression,
+                compressors=compression,
                 dtype=dtype,
                 zarr_format=2
             )

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -435,7 +435,7 @@ def zarrv3_to_ngff_group(zarr_fn, output, *args, block_cc=1, chunknum=-1, **kwar
             numblocks = calculate_blocks(zshape,**kwargs)
             with concurrent.futures.ProcessPoolExecutor(max_workers=block_cc) as e:
                 futs = []
-                for n in range(numblocks):
+                for n in [4,5]:#range(numblocks):
                     futs.append(e.submit(write_zarrv3_to_zarr,zarr_fn,*args,slice_concurrency=block_cc, chunknum=n, **kwargs))
                     sleep(1)
                 for fut in concurrent.futures.as_completed(futs):

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -334,7 +334,7 @@ def write_zarrv3_to_zarr(
     workers = concurrency // slice_concurrency
     
     # updating for zarr v3 store and array creation
-    with z5py.File(output_n5,use_zarr_format=True) as f:
+    with z5py.File(output_n5,use_zarr_format=True,dimension_separator='/') as f:
         mip_ds = {}
         # create groups with attributes according to omezarr spec
         # if len(group_names) == 1:

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -331,8 +331,9 @@ def write_zarrv3_to_zarr(
     # TODO DESKEW: does this generally work regardless of skew?
 
     workers = concurrency // slice_concurrency
-
-    zstore = zarr.DirectoryStore(output_n5, dimension_separator='/')
+    
+    # updating for zarr v3 store and array creation
+    zstore = zarr.storage.LocalStore(output_n5, dimension_separator='/')
     with zarr.open(zstore, mode='a') as f:
         mip_ds = {}
         # create groups with attributes according to omezarr spec
@@ -372,12 +373,13 @@ def write_zarrv3_to_zarr(
         for mip_lvl in range(max_mip + 1):
             if not mip_lvl in g:
                 mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
-                ds_lvl = g.create_dataset(
+                ds_lvl = g.create_array(
                     f"{mip_lvl}",
                     chunks=chunk_size,
                     shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
                     compression=compression,
-                    dtype=dtype
+                    dtype=dtype,
+                    zarr_format=2
                 )
             else:
                 ds_lvl = g[mip_lvl]

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -334,79 +334,82 @@ def write_zarrv3_to_zarr(
     
     # updating for zarr v3 store and array creation
     zstore = zarr.storage.LocalStore(output_n5)
-    with zarr.open(zstore, mode='a') as f:
-        mip_ds = {}
-        # create groups with attributes according to omezarr spec
-        if len(group_names) == 1:
-            group_name = group_names[0]
-            if group_name in f:
-                g = f[f"{group_name}"]
-            else:
-                g = f.create_group(f"{group_name}")
-            # try:
-            #     g = f.create_group(f"{group_name}")
-            # except KeyError:
-            #     g = f[f"{group_name}"]
-                
-            if group_attributes:
-                try:
-                    attributes = group_attributes[0]
-                except IndexError:
-                    print('attributes error')
-            else:
-                attributes = {}
-
-            if "pixelResolution" in attributes:
-                if deskew_options:
-                    attributes["pixelResolution"]["dimensions"][2] /= deskew_options["deskew_stride"]
-                attributes = omezarr_attrs(
-                    group_name, attributes["position"], attributes["pixelResolution"]["dimensions"], max_mip)
-            if attributes:
-                for k, v in attributes.items():
-                    g.attrs[k] = v
+    f = zarr.open(zstore, mode='a')
+    mip_ds = {}
+    # create groups with attributes according to omezarr spec
+    if len(group_names) == 1:
+        group_name = group_names[0]
+        if group_name in f:
+            g = f[f"{group_name}"]
         else:
-            raise TiffToNGFFValueError("only one group name expected")
-        scales = []
+            g = f.create_group(f"{group_name}")
+        # try:
+        #     g = f.create_group(f"{group_name}")
+        # except KeyError:
+        #     g = f[f"{group_name}"]
+            
+        if group_attributes:
+            try:
+                attributes = group_attributes[0]
+            except IndexError:
+                print('attributes error')
+        else:
+            attributes = {}
 
-        # shuffle=Blosc.BITSHUFFLE)
-        compression = Blosc(cname='zstd', clevel=1)
-        for mip_lvl in range(max_mip + 1):
-            if not mip_lvl in g:
-                mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
-                ds_lvl = g.create_array(
-                    f"{mip_lvl}",
-                    chunks=chunk_size,
-                    shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
-                    compression=compression,
-                    dtype=dtype,
-                    zarr_format=2
-                )
-            else:
-                ds_lvl = g[mip_lvl]
-            dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
-            mip_ds[mip_lvl] = ds_lvl
-            scales.append(dsfactors)
-        
-        nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
-        print(str(nblocks) + " number of chunks per axis")
-        print(str(g[0].nchunks) + " chunk number sanity check")
+        if "pixelResolution" in attributes:
+            if deskew_options:
+                attributes["pixelResolution"]["dimensions"][2] /= deskew_options["deskew_stride"]
+            attributes = omezarr_attrs(
+                group_name, attributes["position"], attributes["pixelResolution"]["dimensions"], max_mip)
+        if attributes:
+            for k, v in attributes.items():
+                g.attrs[k] = v
+    else:
+        raise TiffToNGFFValueError("only one group name expected")
+    scales = []
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
-            futs = []
+    # shuffle=Blosc.BITSHUFFLE)
+    compression = Blosc(cname='zstd', clevel=1)
+    for mip_lvl in range(max_mip + 1):
+        if not mip_lvl in g:
+            mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
+            ds_lvl = g.create_array(
+                f"{mip_lvl}",
+                chunks=chunk_size,
+                shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
+                compression=compression,
+                dtype=dtype,
+                zarr_format=2
+            )
+        else:
+            ds_lvl = g[mip_lvl]
+        dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
+        mip_ds[mip_lvl] = ds_lvl
+        scales.append(dsfactors)
+    
+    nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
+    print(str(nblocks) + " number of chunks per axis")
+    print(str(g[0].nchunks) + " chunk number sanity check")
+
+    #currently no context manager support for zarr python v3...
+    #with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
+    e = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
+    futs = []
+    mips = []
+    for miparr in iterate_mip_levels_from_dataset(
+            zarray, max_mip, max_mip, nblocks, block_size, mip_dsfactor,
+            chunknum=chunknum,
+            lvl_to_mip_kwargs=lvl_to_mip_kwargs,
+            interleaved_channels=interleaved_channels,
+            channel=channel, deskew_kwargs=deskew_kwargs):
+        mips.append(miparr)
+        if miparr.lvl == max_mip:
+            futs.append(e.submit(
+                write_mips, mip_ds, mips))
             mips = []
-            for miparr in iterate_mip_levels_from_dataset(
-                    zarray, max_mip, max_mip, nblocks, block_size, mip_dsfactor,
-                    chunknum=chunknum,
-                    lvl_to_mip_kwargs=lvl_to_mip_kwargs,
-                    interleaved_channels=interleaved_channels,
-                    channel=channel, deskew_kwargs=deskew_kwargs):
-                mips.append(miparr)
-                if miparr.lvl == max_mip:
-                    futs.append(e.submit(
-                        write_mips, mip_ds, mips))
-                    mips = []
-            for fut in concurrent.futures.as_completed(futs):
-                _ = fut.result()
+    for fut in concurrent.futures.as_completed(futs):
+        _ = fut.result()
+    e.shutdown(wait=True)
     print("conversion complete, closing file")
 
 

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -336,55 +336,6 @@ def write_zarrv3_to_zarr(
     # updating for zarr v3 store and array creation
     with z5py.File(output_n5,use_zarr_format=True,dimension_separator='/') as f:
         mip_ds = {}
-        # create groups with attributes according to omezarr spec
-        # if len(group_names) == 1:
-        #     group_name = group_names[0]
-        #     if group_name in f:
-        #         g = f[f"{group_name}"]
-        #     else:
-        #         g = f.create_group(f"{group_name}")
-        #     # try:
-        #     #     g = f.create_group(f"{group_name}")
-        #     # except KeyError:
-        #     #     g = f[f"{group_name}"]
-                
-        #     if group_attributes:
-        #         try:
-        #             attributes = group_attributes[0]
-        #         except IndexError:
-        #             print('attributes error')
-        #     else:
-        #         attributes = {}
-    
-        #     if "pixelResolution" in attributes:
-        #         if deskew_options:
-        #             attributes["pixelResolution"]["dimensions"][2] /= deskew_options["deskew_stride"]
-        #         attributes = omezarr_attrs(
-        #             group_name, attributes["position"], attributes["pixelResolution"]["dimensions"], max_mip)
-        #     if attributes:
-        #         for k, v in attributes.items():
-        #             g.attrs[k] = v
-        # else:
-        #     raise TiffToNGFFValueError("only one group name expected")
-        # scales = []
-    
-        # # shuffle=Blosc.BITSHUFFLE)
-        # compression = Blosc(cname='zstd', clevel=1)
-        # for mip_lvl in range(max_mip + 1):
-        #     if not mip_lvl in g.array_keys():
-        #         mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
-        #         ds_lvl = g.create_array(
-        #             f"{mip_lvl}",
-        #             chunks=chunk_size,
-        #             shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
-        #             compressors=compression,
-        #             dtype=dtype
-        #         )
-        #     else:
-        #         ds_lvl = g[mip_lvl]
-        #     dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
-        #     mip_ds[mip_lvl] = ds_lvl
-        #     scales.append(dsfactors)
         if len(group_names) == 1:
             group_name = group_names[0]
             if group_name in f:
@@ -414,15 +365,18 @@ def write_zarrv3_to_zarr(
         
         for mip_lvl in range(max_mip + 1):
             mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
-            try:
-                ds_lvl = g.create_dataset(
-                    f"{mip_lvl}",
-                    chunks=chunk_size,
-                    shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
-                    compression=compression,
-                    dtype=dtype
-                )
-            except ValueError:
+            if not str(mip_lvl) in g:
+                try:
+                    ds_lvl = g.create_dataset(
+                        f"{mip_lvl}",
+                        chunks=chunk_size,
+                        shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
+                        compression=compression,
+                        dtype=dtype
+                    )
+                except:
+                    ds_lvl = g[str(mip_lvl)]
+            else:
                 ds_lvl = g[str(mip_lvl)]
             dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
             mip_ds[mip_lvl] = ds_lvl
@@ -430,7 +384,6 @@ def write_zarrv3_to_zarr(
         
         nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
         print(str(nblocks) + " number of chunks per axis")
-        #print(str(g[0].nchunks) + " chunk number sanity check")
     
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
             futs = []

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -437,8 +437,8 @@ def zarrv3_to_ngff_group(zarr_fn, output, *args, block_cc=1, chunknum=-1, **kwar
         if chunknum > -1:
             return write_zarrv3_to_zarr(zarr_fn, *args, slice_concurrency=1, chunknum=chunknum, **kwargs)
         else:
-            with zarr.open(zarr_fn) as zf:
-                zshape = zf['0'].shape
+            zf = zarr.open(zarr_fn)
+            zshape = zf['0'].shape
             numblocks = calculate_blocks(zshape,**kwargs)
             with concurrent.futures.ProcessPoolExecutor(max_workers=block_cc) as e:
                 futs = []

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -371,7 +371,7 @@ def write_zarrv3_to_zarr(
     # shuffle=Blosc.BITSHUFFLE)
     compression = Blosc(cname='zstd', clevel=1)
     for mip_lvl in range(max_mip + 1):
-        if not mip_lvl in g:
+        if not mip_lvl in g.array_keys():
             mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
             ds_lvl = g.create_array(
                 f"{mip_lvl}",

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -387,14 +387,18 @@ def write_zarrv3_to_zarr(
         #     scales.append(dsfactors)
         if len(group_names) == 1:
             group_name = group_names[0]
-            try:
-                g = f.create_group(f"{group_name}")
-            except KeyError:
+            if group_name in f:
                 g = f[f"{group_name}"]
-            try:
-                attributes = group_attributes[0]
-            except IndexError:
-                print('attributes error')
+            else:
+                g = f.create_group(f"{group_name}")
+                
+            if group_attributes:
+                try:
+                    attributes = group_attributes[0]
+                except IndexError:
+                    print('attributes error')
+            else:
+                attributes = {}
 
             if "pixelResolution" in attributes:
                 if deskew_options:
@@ -407,6 +411,7 @@ def write_zarrv3_to_zarr(
         else:
             raise TiffToNGFFValueError("only one group name expected")
         scales = []
+        
         for mip_lvl in range(max_mip + 1):
             ds_lvl = g.create_dataset(
                 f"{mip_lvl}",

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -12,6 +12,7 @@ import numpy
 # import skimage
 
 import zarr
+import z5py
 from numcodecs import Blosc
 import argschema
 
@@ -333,83 +334,113 @@ def write_zarrv3_to_zarr(
     workers = concurrency // slice_concurrency
     
     # updating for zarr v3 store and array creation
-    zstore = zarr.storage.LocalStore(output_n5)
-    f = zarr.open(zstore, mode='a')
-    mip_ds = {}
-    # create groups with attributes according to omezarr spec
-    if len(group_names) == 1:
-        group_name = group_names[0]
-        if group_name in f:
-            g = f[f"{group_name}"]
-        else:
-            g = f.create_group(f"{group_name}")
-        # try:
-        #     g = f.create_group(f"{group_name}")
-        # except KeyError:
-        #     g = f[f"{group_name}"]
-            
-        if group_attributes:
+    with z5py.File(output_n5) as f:
+        mip_ds = {}
+        # create groups with attributes according to omezarr spec
+        # if len(group_names) == 1:
+        #     group_name = group_names[0]
+        #     if group_name in f:
+        #         g = f[f"{group_name}"]
+        #     else:
+        #         g = f.create_group(f"{group_name}")
+        #     # try:
+        #     #     g = f.create_group(f"{group_name}")
+        #     # except KeyError:
+        #     #     g = f[f"{group_name}"]
+                
+        #     if group_attributes:
+        #         try:
+        #             attributes = group_attributes[0]
+        #         except IndexError:
+        #             print('attributes error')
+        #     else:
+        #         attributes = {}
+    
+        #     if "pixelResolution" in attributes:
+        #         if deskew_options:
+        #             attributes["pixelResolution"]["dimensions"][2] /= deskew_options["deskew_stride"]
+        #         attributes = omezarr_attrs(
+        #             group_name, attributes["position"], attributes["pixelResolution"]["dimensions"], max_mip)
+        #     if attributes:
+        #         for k, v in attributes.items():
+        #             g.attrs[k] = v
+        # else:
+        #     raise TiffToNGFFValueError("only one group name expected")
+        # scales = []
+    
+        # # shuffle=Blosc.BITSHUFFLE)
+        # compression = Blosc(cname='zstd', clevel=1)
+        # for mip_lvl in range(max_mip + 1):
+        #     if not mip_lvl in g.array_keys():
+        #         mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
+        #         ds_lvl = g.create_array(
+        #             f"{mip_lvl}",
+        #             chunks=chunk_size,
+        #             shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
+        #             compressors=compression,
+        #             dtype=dtype
+        #         )
+        #     else:
+        #         ds_lvl = g[mip_lvl]
+        #     dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
+        #     mip_ds[mip_lvl] = ds_lvl
+        #     scales.append(dsfactors)
+        group_objs = []
+        for i, group_name in enumerate(group_names):
             try:
-                attributes = group_attributes[0]
+                g = group_objs[-1].create_group(f"{group_name}")
             except IndexError:
-                print('attributes error')
-        else:
-            attributes = {}
-
-        if "pixelResolution" in attributes:
+                try:
+                    g = f.create_group(f"{group_name}")
+                except KeyError:
+                    g = f[f"{group_name}"]
+            group_objs.append(g)
+            try:
+                attributes = group_attributes[i]
+            except IndexError:
+                continue
             if deskew_options:
-                attributes["pixelResolution"]["dimensions"][2] /= deskew_options["deskew_stride"]
-            attributes = omezarr_attrs(
-                group_name, attributes["position"], attributes["pixelResolution"]["dimensions"], max_mip)
-        if attributes:
+                if "pixelResolution" in attributes:
+                    attributes["pixelResolution"]["dimensions"][0] /= deskew_options["deskew_stride"]
             for k, v in attributes.items():
                 g.attrs[k] = v
-    else:
-        raise TiffToNGFFValueError("only one group name expected")
-    scales = []
-
-    # shuffle=Blosc.BITSHUFFLE)
-    compression = Blosc(cname='zstd', clevel=1)
-    for mip_lvl in range(max_mip + 1):
-        if not mip_lvl in g.array_keys():
-            mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
-            ds_lvl = g.create_array(
-                f"{mip_lvl}",
+        scales = []
+        for mip_lvl in range(max_mip + 1):
+            ds_lvl = g.create_dataset(
+                f"s{mip_lvl}",
                 chunks=chunk_size,
-                shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
-                compressors=compression,
+                shape=mip_level_shape(mip_lvl, joined_shapes),
+                compression=compression,
                 dtype=dtype,
-                zarr_format=2
-            )
-        else:
-            ds_lvl = g[mip_lvl]
-        dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
-        mip_ds[mip_lvl] = ds_lvl
-        scales.append(dsfactors)
+                n_threads=slice_concurrency)
+            dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
+            ds_lvl.attrs["downsamplingFactors"] = dsfactors
+            mip_ds[mip_lvl] = ds_lvl
+            scales.append(dsfactors)
+        g.attrs["scales"] = scales
+        group_objs[0].attrs["downsamplingFactors"] = scales
+        group_objs[0].attrs["dataType"] = dtype
+        
+        nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
+        print(str(nblocks) + " number of chunks per axis")
+        print(str(g[0].nchunks) + " chunk number sanity check")
     
-    nblocks = [int(numpy.ceil(joined_shapes[k]/block_size[k])) for k in range(3)]
-    print(str(nblocks) + " number of chunks per axis")
-    print(str(g[0].nchunks) + " chunk number sanity check")
-
-    #currently no context manager support for zarr python v3...
-    #with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
-    e = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
-    futs = []
-    mips = []
-    for miparr in iterate_mip_levels_from_dataset(
-            zarray, max_mip, max_mip, nblocks, block_size, mip_dsfactor,
-            chunknum=chunknum,
-            lvl_to_mip_kwargs=lvl_to_mip_kwargs,
-            interleaved_channels=interleaved_channels,
-            channel=channel, deskew_kwargs=deskew_kwargs):
-        mips.append(miparr)
-        if miparr.lvl == max_mip:
-            futs.append(e.submit(
-                write_mips, mip_ds, mips))
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as e:
+            futs = []
             mips = []
-    for fut in concurrent.futures.as_completed(futs):
-        _ = fut.result()
-    e.shutdown(wait=True)
+            for miparr in iterate_mip_levels_from_dataset(
+                    zarray, max_mip, max_mip, nblocks, block_size, mip_dsfactor,
+                    chunknum=chunknum,
+                    lvl_to_mip_kwargs=lvl_to_mip_kwargs,
+                    interleaved_channels=interleaved_channels,
+                    channel=channel, deskew_kwargs=deskew_kwargs):
+                mips.append(miparr)
+                if miparr.lvl == max_mip:
+                    futs.append(e.submit(
+                        write_mips, mip_ds, mips))
+                    mips = []
+            for fut in concurrent.futures.as_completed(futs):
+                _ = fut.result()
     print("conversion complete, closing file")
 
 

--- a/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
+++ b/acpreprocessing/stitching_modules/convert_to_n5/zarrv3_to_ngff.py
@@ -413,15 +413,29 @@ def write_zarrv3_to_zarr(
         scales = []
         
         for mip_lvl in range(max_mip + 1):
-            ds_lvl = g.create_dataset(
-                f"{mip_lvl}",
-                chunks=chunk_size,
-                shape=mip_level_shape(mip_lvl, joined_shapes),
-                compression=compression,
-                dtype=dtype,
-                n_threads=slice_concurrency)
+            # ds_lvl = g.create_dataset(
+            #     f"{mip_lvl}",
+            #     chunks=chunk_size,
+            #     shape=mip_level_shape(mip_lvl, joined_shapes),
+            #     compression=compression,
+            #     dtype=dtype,
+            #     n_threads=slice_concurrency)
+            # dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
+            # ds_lvl.attrs["downsamplingFactors"] = dsfactors
+            # mip_ds[mip_lvl] = ds_lvl
+            # scales.append(dsfactors)
+            if not mip_lvl in g:
+                mip_3dshape = mip_level_shape(mip_lvl, joined_shapes)
+                ds_lvl = g.create_dataset(
+                    f"{mip_lvl}",
+                    chunks=chunk_size,
+                    shape=(1, 1, mip_3dshape[0], mip_3dshape[1], mip_3dshape[2]),
+                    compression=compression,
+                    dtype=dtype
+                )
+            else:
+                ds_lvl = g[mip_lvl]
             dsfactors = [int(i)**mip_lvl for i in mip_dsfactor]
-            ds_lvl.attrs["downsamplingFactors"] = dsfactors
             mip_ds[mip_lvl] = ds_lvl
             scales.append(dsfactors)
         


### PR DESCRIPTION
# Description

This is a potentially breaking change to add a new feature (zarrv3 to ngff) to be able to read the data from new Exaspim acquisitions which are written to sharded zarr v3 datasets. The breaking change is that zarr-python v3 does not appear to function with full backward compatibility to v2 which is a central package in the data conversion in the existing processes e.g. tiff to ngff and ims to ngff.

## Type of change
<!-- Please copy one of the commented-out lines below to describe the scope of this change -->
<!--
Bug Fix (non-breaking change fixing unexpected behavior)
New Feature (non-breaking change adding functionality)
Breaking change (fix or feature which may break existing functionality)
Maintenance (Minimal functionality changes e.g. documentation, formatting, adding tests)
-->
Breaking change (fix or feature which may break existing functionality)

## Checklist
- [ ] Modified code is covered in tests (currently not required)
- [ ] PR is based on correct branch (this is likely `develop`)
- [ ] Code is pep8 compliant
- [ ] New methods have NumpyDoc compliant docstrings
